### PR TITLE
Refactor register combiner code

### DIFF
--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -317,25 +317,27 @@ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool 
 
     QString *res;
     switch (in.mod) {
-    case PS_INPUTMAPPING_SIGNED_IDENTITY:
     case PS_INPUTMAPPING_UNSIGNED_IDENTITY:
-        qobject_ref(reg);
-        res = reg;
+        res = qstring_from_fmt("max(%s, 0.0)", qstring_get_str(reg));
         break;
     case PS_INPUTMAPPING_UNSIGNED_INVERT:
-        res = qstring_from_fmt("(1.0 - %s)", qstring_get_str(reg));
+        res = qstring_from_fmt("(1.0 - clamp(%s, 0.0, 1.0))", qstring_get_str(reg));
         break;
-    case PS_INPUTMAPPING_EXPAND_NORMAL: // TODO: Change to max(0, x)??
-        res = qstring_from_fmt("(2.0 * %s - 1.0)", qstring_get_str(reg));
+    case PS_INPUTMAPPING_EXPAND_NORMAL:
+        res = qstring_from_fmt("(2.0 * max(%s, 0.0) - 1.0)", qstring_get_str(reg));
         break;
     case PS_INPUTMAPPING_EXPAND_NEGATE:
-        res = qstring_from_fmt("(1.0 - 2.0 * %s)", qstring_get_str(reg));
+        res = qstring_from_fmt("(-2.0 * max(%s, 0.0) + 1.0)", qstring_get_str(reg));
         break;
     case PS_INPUTMAPPING_HALFBIAS_NORMAL:
-        res = qstring_from_fmt("(%s - 0.5)", qstring_get_str(reg));
+        res = qstring_from_fmt("(max(%s, 0.0) - 0.5)", qstring_get_str(reg));
         break;
     case PS_INPUTMAPPING_HALFBIAS_NEGATE:
-        res = qstring_from_fmt("(0.5 - %s)", qstring_get_str(reg));
+        res = qstring_from_fmt("(-max(%s, 0.0) + 0.5)", qstring_get_str(reg));
+        break;
+    case PS_INPUTMAPPING_SIGNED_IDENTITY:
+        qobject_ref(reg);
+        res = reg;
         break;
     case PS_INPUTMAPPING_SIGNED_NEGATE:
         res = qstring_from_fmt("-%s", qstring_get_str(reg));

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -453,8 +453,9 @@ static void add_stage_code(struct PixelShader *ps,
         if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
             sum = qstring_from_fmt("(%s + %s)", qstring_get_str(ab), qstring_get_str(cd));
         } else {
-            sum = qstring_from_fmt("((r0.a >= 0.5) ? %s : %s)",
-                                   qstring_get_str(cd), qstring_get_str(ab));
+            assert(ps->flags & PS_COMBINERCOUNT_MUX_MSB);
+            sum = qstring_from_fmt("mix(%s, %s, r0.a < 0.5)",
+                                   qstring_get_str(ab), qstring_get_str(cd));
         }
         QString *sum_mapping = get_output(sum, output.mapping);
 

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -479,6 +479,10 @@ static void add_stage_code(struct PixelShader *ps,
     }
 
     if (output.muxsum != PS_REGISTER_DISCARD) {
+
+        assert(output.ab_op != PS_COMBINEROUTPUT_AB_DOT_PRODUCT);
+        assert(output.cd_op != PS_COMBINEROUTPUT_CD_DOT_PRODUCT);
+
         if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
             qstring_append_fmt(ps->code, "sum_in.%s = (ab_in.%s + cd_in.%s);\n",
                                write_mask, write_mask, write_mask);

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -484,8 +484,9 @@ static void add_stage_code(struct PixelShader *ps,
                                write_mask, write_mask, write_mask);
         } else {
             assert(ps->flags & PS_COMBINERCOUNT_MUX_MSB);
-            qstring_append_fmt(ps->code, "sum_in.%s = mix(ab_in.%s, cd_in.%s, r0.a < 0.5);\n",
-                               write_mask, write_mask, write_mask);
+            qstring_append_fmt(ps->code, "sum_in.%s = mix(ab_in.%s, cd_in.%s, %s(r0.a < 0.5));\n",
+                               write_mask, write_mask, write_mask,
+                               is_alpha ? "bool" : "bvec3");
         }
 
         QString* sum_reg = qstring_from_fmt("sum_in.%s", write_mask);

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -209,6 +209,8 @@ struct PixelShader {
     char const_refs[32][32];
 };
 
+ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool is_alpha);
+
 static void add_var_ref(struct PixelShader *ps, const char *var)
 {
     int i;
@@ -228,16 +230,9 @@ static void add_const_ref(struct PixelShader *ps, const char *var)
 }
 
 // Get the code for a variable used in the program
-static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
+static QString* get_var(struct PixelShader *ps, int reg)
 {
     switch (reg) {
-    case PS_REGISTER_DISCARD:
-        if (is_dest) {
-            return qstring_from_str("");
-        } else {
-            return qstring_from_str("0.0");
-        }
-        break;
     case PS_REGISTER_C0:
         if (ps->flags & PS_COMBINERCOUNT_UNIQUE_C0 || ps->cur_stage == 8) {
             QString *reg = qstring_from_fmt("c0_%d", ps->cur_stage);
@@ -280,7 +275,35 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
         return qstring_from_str("r1");
     case PS_REGISTER_V1R0_SUM:
         add_var_ref(ps, "r0");
-        return qstring_from_str("(v1 + r0)");
+
+        struct InputInfo v1_info;
+        v1_info.reg = PS_REGISTER_V1;
+        if (ps->final_input.inv_v1) {
+            v1_info.mod = PS_INPUTMAPPING_UNSIGNED_INVERT;
+        } else {
+            v1_info.mod = PS_INPUTMAPPING_UNSIGNED_IDENTITY;
+        }
+        v1_info.chan = PS_CHANNEL_RGB;
+        QString *v1 = get_input_var(ps, v1_info, false);
+
+        struct InputInfo r0_info;
+        r0_info.reg = PS_REGISTER_R0;
+        if (ps->final_input.inv_r0) {
+            r0_info.mod = PS_INPUTMAPPING_UNSIGNED_INVERT;
+        } else {
+            r0_info.mod = PS_INPUTMAPPING_UNSIGNED_IDENTITY;
+        }
+        r0_info.chan = PS_CHANNEL_RGB;
+        QString *r0 = get_input_var(ps, r0_info, false);
+
+        QString *reg = qstring_from_fmt(ps->final_input.clamp_sum ?
+                                     "vec4(clamp(%s + %s, 0.0, 1.0), 0.0)" :
+                                     "vec4(%s + %s, 0.0)",
+                                        qstring_get_str(v1),
+                                        qstring_get_str(r0));
+        qobject_unref(v1);
+        qobject_unref(r0);
+        return reg;
     case PS_REGISTER_EF_PROD:
         return qstring_from_fmt("(%s * %s)", qstring_get_str(ps->varE),
                                 qstring_get_str(ps->varF));
@@ -293,11 +316,17 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
 // Get input variable code
 static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool is_alpha)
 {
-    QString *reg = get_var(ps, in.reg, false);
 
-    if (strcmp(qstring_get_str(reg), "0.0") != 0
-        && (in.reg != PS_REGISTER_EF_PROD
-            || strstr(qstring_get_str(reg), ".a") == NULL)) {
+    QString *reg;
+    if (in.reg == PS_REGISTER_ZERO) {
+        if (is_alpha) {
+            reg = qstring_from_str("0.0");
+        } else {
+            reg = qstring_from_str("vec3(0.0)");
+        }
+    } else {
+        reg = get_var(ps, in.reg);
+
         switch (in.chan) {
         case PS_CHANNEL_RGB:
             if (is_alpha) {
@@ -307,7 +336,11 @@ static QString* get_input_var(struct PixelShader *ps, struct InputInfo in, bool 
             }
             break;
         case PS_CHANNEL_ALPHA:
-            qstring_append(reg, ".a");
+            if (is_alpha) {
+                qstring_append(reg, ".a");
+            } else {
+                qstring_append(reg, ".aaa");
+            }
             break;
         default:
             assert(false);
@@ -385,21 +418,20 @@ static QString* get_output(QString *reg, int mapping)
 // Add the GLSL code for a stage
 static void add_stage_code(struct PixelShader *ps,
                            struct InputVarInfo input, struct OutputInfo output,
-                           const char *write_mask, bool is_alpha)
+                           bool is_alpha)
 {
+    const char *write_mask = is_alpha ? "a" : "rgb";
+
     QString *a = get_input_var(ps, input.a, is_alpha);
     QString *b = get_input_var(ps, input.b, is_alpha);
     QString *c = get_input_var(ps, input.c, is_alpha);
     QString *d = get_input_var(ps, input.d, is_alpha);
 
-    const char *caster = "";
-    if (strlen(write_mask) == 3) {
-        caster = "vec3";
-    }
 
     QString *ab;
     if (output.ab_op == PS_COMBINEROUTPUT_AB_DOT_PRODUCT) {
-        ab = qstring_from_fmt("dot(%s, %s)",
+        assert(!is_alpha);
+        ab = qstring_from_fmt("vec3(dot(%s, %s))",
                               qstring_get_str(a), qstring_get_str(b));
     } else {
         ab = qstring_from_fmt("(%s * %s)",
@@ -408,7 +440,8 @@ static void add_stage_code(struct PixelShader *ps,
 
     QString *cd;
     if (output.cd_op == PS_COMBINEROUTPUT_CD_DOT_PRODUCT) {
-        cd = qstring_from_fmt("dot(%s, %s)",
+        assert(!is_alpha);
+        cd = qstring_from_fmt("vec3(dot(%s, %s))",
                               qstring_get_str(c), qstring_get_str(d));
     } else {
         cd = qstring_from_fmt("(%s * %s)",
@@ -416,11 +449,11 @@ static void add_stage_code(struct PixelShader *ps,
     }
 
     if (output.ab != PS_REGISTER_DISCARD) {
-        QString *ab_dest = get_var(ps, output.ab, true);
+        QString *ab_dest = get_var(ps, output.ab);
         QString *ab_mapping = get_output(ab, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
-                           qstring_get_str(ab_dest), write_mask, caster, qstring_get_str(ab_mapping));
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
+                           qstring_get_str(ab_dest), write_mask, qstring_get_str(ab_mapping));
 
         /* FIXME: Will these still write rgb? */
         if (!is_alpha && output.flags & PS_COMBINEROUTPUT_AB_BLUE_TO_ALPHA) {
@@ -433,11 +466,11 @@ static void add_stage_code(struct PixelShader *ps,
     }
 
     if (output.cd != PS_REGISTER_DISCARD) {
-        QString *cd_dest = get_var(ps, output.cd, true);
+        QString *cd_dest = get_var(ps, output.cd);
         QString *cd_mapping = get_output(cd, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
-                           qstring_get_str(cd_dest), write_mask, caster, qstring_get_str(cd_mapping));
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
+                           qstring_get_str(cd_dest), write_mask, qstring_get_str(cd_mapping));
 
         /* FIXME: Will these still write rgb? */
         if (!is_alpha && output.flags & PS_COMBINEROUTPUT_CD_BLUE_TO_ALPHA) {
@@ -450,7 +483,7 @@ static void add_stage_code(struct PixelShader *ps,
     }
 
     if (output.muxsum != PS_REGISTER_DISCARD) {
-        QString *sum_dest = get_var(ps, output.muxsum, true);
+        QString *sum_dest = get_var(ps, output.muxsum);
         QString *sum;
         if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
             sum = qstring_from_fmt("(%s + %s)", qstring_get_str(ab), qstring_get_str(cd));
@@ -461,8 +494,8 @@ static void add_stage_code(struct PixelShader *ps,
         }
         QString *sum_mapping = get_output(sum, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
-                           qstring_get_str(sum_dest), write_mask, caster, qstring_get_str(sum_mapping));
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
+                           qstring_get_str(sum_dest), write_mask, qstring_get_str(sum_mapping));
 
         qobject_unref(sum);
         qobject_unref(sum_mapping);
@@ -489,7 +522,7 @@ static void add_final_stage_code(struct PixelShader *ps, struct FCInputInfo fina
     QString *d = get_input_var(ps, final.d, false);
     QString *g = get_input_var(ps, final.g, true);
 
-    qstring_append_fmt(ps->code, "fragColor.rgb = %s + mix(vec3(%s), vec3(%s), vec3(%s));\n",
+    qstring_append_fmt(ps->code, "fragColor.rgb = %s + mix(%s, %s, %s);\n",
                        qstring_get_str(d), qstring_get_str(c),
                        qstring_get_str(b), qstring_get_str(a));
     qstring_append_fmt(ps->code, "fragColor.a = %s;\n", qstring_get_str(g));
@@ -713,8 +746,8 @@ static QString* psh_convert(struct PixelShader *ps)
     for (i = 0; i < ps->num_stages; i++) {
         ps->cur_stage = i;
         qstring_append_fmt(ps->code, "// Stage %d\n", i);
-        add_stage_code(ps, ps->stage[i].rgb_input, ps->stage[i].rgb_output, "rgb", false);
-        add_stage_code(ps, ps->stage[i].alpha_input, ps->stage[i].alpha_output, "a", true);
+        add_stage_code(ps, ps->stage[i].rgb_input, ps->stage[i].rgb_output, false);
+        add_stage_code(ps, ps->stage[i].alpha_input, ps->stage[i].alpha_output, true);
     }
 
     if (ps->final_input.enabled) {

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -413,51 +413,57 @@ static void add_stage_code(struct PixelShader *ps,
                               qstring_get_str(c), qstring_get_str(d));
     }
 
-    QString *ab_mapping = get_output(ab, output.mapping);
-    QString *cd_mapping = get_output(cd, output.mapping);
-    QString *ab_dest = get_var(ps, output.ab, true);
-    QString *cd_dest = get_var(ps, output.cd, true);
-    QString *sum_dest = get_var(ps, output.muxsum, true);
+    if (output.ab != PS_REGISTER_DISCARD) {
+        QString *ab_dest = get_var(ps, output.ab, true);
+        QString *ab_mapping = get_output(ab, output.mapping);
 
-    if (qstring_get_length(ab_dest)) {
         qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
                            qstring_get_str(ab_dest), write_mask, caster, qstring_get_str(ab_mapping));
-    } else {
+
+        /* FIXME: Will these still write rgb? */
+        if (!is_alpha && output.flags & PS_COMBINEROUTPUT_AB_BLUE_TO_ALPHA) {
+            qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
+                               qstring_get_str(ab_dest), qstring_get_str(ab_dest));
+        }
+
+        qobject_unref(ab_mapping);
         qobject_unref(ab_dest);
-        qobject_ref(ab_mapping);
-        ab_dest = ab_mapping;
     }
 
-    if (qstring_get_length(cd_dest)) {
+    if (output.cd != PS_REGISTER_DISCARD) {
+        QString *cd_dest = get_var(ps, output.cd, true);
+        QString *cd_mapping = get_output(cd, output.mapping);
+
         qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
                            qstring_get_str(cd_dest), write_mask, caster, qstring_get_str(cd_mapping));
-    } else {
+
+        /* FIXME: Will these still write rgb? */
+        if (!is_alpha && output.flags & PS_COMBINEROUTPUT_CD_BLUE_TO_ALPHA) {
+            qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
+                               qstring_get_str(cd_dest), qstring_get_str(cd_dest));
+        }
+
+        qobject_unref(cd_mapping);
         qobject_unref(cd_dest);
-        qobject_ref(cd_mapping);
-        cd_dest = cd_mapping;
     }
 
-    if (!is_alpha && output.flags & PS_COMBINEROUTPUT_AB_BLUE_TO_ALPHA) {
-        qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
-                           qstring_get_str(ab_dest), qstring_get_str(ab_dest));
-    }
-    if (!is_alpha && output.flags & PS_COMBINEROUTPUT_CD_BLUE_TO_ALPHA) {
-        qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
-                           qstring_get_str(cd_dest), qstring_get_str(cd_dest));
-    }
+    if (output.muxsum != PS_REGISTER_DISCARD) {
+        QString *sum_dest = get_var(ps, output.muxsum, true);
+        QString *sum;
+        if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
+            sum = qstring_from_fmt("(%s + %s)", qstring_get_str(ab), qstring_get_str(cd));
+        } else {
+            sum = qstring_from_fmt("((r0.a >= 0.5) ? %s : %s)",
+                                   qstring_get_str(cd), qstring_get_str(ab));
+        }
+        QString *sum_mapping = get_output(sum, output.mapping);
 
-    QString *sum;
-    if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
-        sum = qstring_from_fmt("(%s + %s)", qstring_get_str(ab), qstring_get_str(cd));
-    } else {
-        sum = qstring_from_fmt("((r0.a >= 0.5) ? %s : %s)",
-                               qstring_get_str(cd), qstring_get_str(ab));
-    }
-
-    QString *sum_mapping = get_output(sum, output.mapping);
-    if (qstring_get_length(sum_dest)) {
         qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
                            qstring_get_str(sum_dest), write_mask, caster, qstring_get_str(sum_mapping));
+
+        qobject_unref(sum);
+        qobject_unref(sum_mapping);
+        qobject_unref(sum_dest);
     }
 
     qobject_unref(a);
@@ -466,13 +472,6 @@ static void add_stage_code(struct PixelShader *ps,
     qobject_unref(d);
     qobject_unref(ab);
     qobject_unref(cd);
-    qobject_unref(ab_mapping);
-    qobject_unref(cd_mapping);
-    qobject_unref(ab_dest);
-    qobject_unref(cd_dest);
-    qobject_unref(sum_dest);
-    qobject_unref(sum);
-    qobject_unref(sum_mapping);
 }
 
 // Add code for the final combiner stage

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -419,7 +419,7 @@ static void add_stage_code(struct PixelShader *ps,
         QString *ab_dest = get_var(ps, output.ab, true);
         QString *ab_mapping = get_output(ab, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(ab_dest), write_mask, caster, qstring_get_str(ab_mapping));
 
         /* FIXME: Will these still write rgb? */
@@ -436,7 +436,7 @@ static void add_stage_code(struct PixelShader *ps,
         QString *cd_dest = get_var(ps, output.cd, true);
         QString *cd_mapping = get_output(cd, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(cd_dest), write_mask, caster, qstring_get_str(cd_mapping));
 
         /* FIXME: Will these still write rgb? */
@@ -461,7 +461,7 @@ static void add_stage_code(struct PixelShader *ps,
         }
         QString *sum_mapping = get_output(sum, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = %s(%s);\n",
+        qstring_append_fmt(ps->code, "%s.%s = clamp(%s(%s), -1.0, 1.0);\n",
                            qstring_get_str(sum_dest), write_mask, caster, qstring_get_str(sum_mapping));
 
         qobject_unref(sum);

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -415,7 +415,7 @@ static QString* get_output(QString *reg, int mapping)
     return res;
 }
 
-// Add the GLSL code for a stage
+// Add the GLSL code for a stage which does operation
 static void add_stage_code(struct PixelShader *ps,
                            struct InputVarInfo input, struct OutputInfo output,
                            bool is_alpha)
@@ -428,86 +428,106 @@ static void add_stage_code(struct PixelShader *ps,
     QString *d = get_input_var(ps, input.d, is_alpha);
 
 
-    QString *ab;
     if (output.ab_op == PS_COMBINEROUTPUT_AB_DOT_PRODUCT) {
         assert(!is_alpha);
-        ab = qstring_from_fmt("vec3(dot(%s, %s))",
-                              qstring_get_str(a), qstring_get_str(b));
+        qstring_append_fmt(ps->code, "ab_in.%s = vec3(dot(%s, %s));\n",
+                           write_mask, qstring_get_str(a), qstring_get_str(b));
     } else {
-        ab = qstring_from_fmt("(%s * %s)",
-                              qstring_get_str(a), qstring_get_str(b));
+        qstring_append_fmt(ps->code, "ab_in.%s = (%s * %s);\n",
+                           write_mask, qstring_get_str(a), qstring_get_str(b));
     }
 
-    QString *cd;
     if (output.cd_op == PS_COMBINEROUTPUT_CD_DOT_PRODUCT) {
         assert(!is_alpha);
-        cd = qstring_from_fmt("vec3(dot(%s, %s))",
-                              qstring_get_str(c), qstring_get_str(d));
+        qstring_append_fmt(ps->code, "cd_in.%s = vec3(dot(%s, %s));\n",
+                           write_mask, qstring_get_str(c), qstring_get_str(d));
     } else {
-        cd = qstring_from_fmt("(%s * %s)",
-                              qstring_get_str(c), qstring_get_str(d));
+        qstring_append_fmt(ps->code, "cd_in.%s = (%s * %s);\n",
+                           write_mask, qstring_get_str(c), qstring_get_str(d));
     }
 
     if (output.ab != PS_REGISTER_DISCARD) {
-        QString *ab_dest = get_var(ps, output.ab);
-        QString *ab_mapping = get_output(ab, output.mapping);
+        QString* ab_reg = qstring_from_fmt("ab_in.%s", write_mask);
+        QString *ab_mapping = get_output(ab_reg, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
-                           qstring_get_str(ab_dest), write_mask, qstring_get_str(ab_mapping));
+        qstring_append_fmt(ps->code, "ab_out.%s = clamp(%s, -1.0, 1.0);\n",
+                           write_mask, qstring_get_str(ab_mapping));
 
         /* FIXME: Will these still write rgb? */
         if (!is_alpha && output.flags & PS_COMBINEROUTPUT_AB_BLUE_TO_ALPHA) {
-            qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
-                               qstring_get_str(ab_dest), qstring_get_str(ab_dest));
+            qstring_append_fmt(ps->code, "ab_out.a = ab_out.b;\n");
         }
 
         qobject_unref(ab_mapping);
-        qobject_unref(ab_dest);
+        qobject_unref(ab_reg);
     }
 
     if (output.cd != PS_REGISTER_DISCARD) {
-        QString *cd_dest = get_var(ps, output.cd);
-        QString *cd_mapping = get_output(cd, output.mapping);
+        QString* cd_reg = qstring_from_fmt("cd_in.%s", write_mask);
+        QString *cd_mapping = get_output(cd_reg, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
-                           qstring_get_str(cd_dest), write_mask, qstring_get_str(cd_mapping));
+        qstring_append_fmt(ps->code, "cd_out.%s = clamp(%s, -1.0, 1.0);\n",
+                           write_mask, qstring_get_str(cd_mapping));
 
         /* FIXME: Will these still write rgb? */
         if (!is_alpha && output.flags & PS_COMBINEROUTPUT_CD_BLUE_TO_ALPHA) {
-            qstring_append_fmt(ps->code, "%s.a = %s.b;\n",
-                               qstring_get_str(cd_dest), qstring_get_str(cd_dest));
+            qstring_append_fmt(ps->code, "cd_out.a = cd_out.b;\n");
         }
 
         qobject_unref(cd_mapping);
-        qobject_unref(cd_dest);
+        qobject_unref(cd_reg);
     }
 
     if (output.muxsum != PS_REGISTER_DISCARD) {
-        QString *sum_dest = get_var(ps, output.muxsum);
-        QString *sum;
         if (output.muxsum_op == PS_COMBINEROUTPUT_AB_CD_SUM) {
-            sum = qstring_from_fmt("(%s + %s)", qstring_get_str(ab), qstring_get_str(cd));
+            qstring_append_fmt(ps->code, "sum_in.%s = (ab_in.%s + cd_in.%s);\n",
+                               write_mask, write_mask, write_mask);
         } else {
             assert(ps->flags & PS_COMBINERCOUNT_MUX_MSB);
-            sum = qstring_from_fmt("mix(%s, %s, r0.a < 0.5)",
-                                   qstring_get_str(ab), qstring_get_str(cd));
+            qstring_append_fmt(ps->code, "sum_in.%s = mix(ab_in.%s, cd_in.%s, r0.a < 0.5);\n",
+                               write_mask, write_mask, write_mask);
         }
-        QString *sum_mapping = get_output(sum, output.mapping);
 
-        qstring_append_fmt(ps->code, "%s.%s = clamp(%s, -1.0, 1.0);\n",
-                           qstring_get_str(sum_dest), write_mask, qstring_get_str(sum_mapping));
+        QString* sum_reg = qstring_from_fmt("sum_in.%s", write_mask);
+        QString *sum_mapping = get_output(sum_reg, output.mapping);
 
-        qobject_unref(sum);
+        qstring_append_fmt(ps->code, "sum_out.%s = clamp(%s, -1.0, 1.0);\n",
+                           write_mask, qstring_get_str(sum_mapping));
+
         qobject_unref(sum_mapping);
-        qobject_unref(sum_dest);
+        qobject_unref(sum_reg);
     }
 
     qobject_unref(a);
     qobject_unref(b);
     qobject_unref(c);
     qobject_unref(d);
-    qobject_unref(ab);
-    qobject_unref(cd);
+}
+
+// Add the GLSL code for a stage which does writeback
+static void add_stage_code_writeback(struct PixelShader *ps,
+                                     struct OutputInfo output,
+                                     bool is_alpha)
+{
+    const char *write_mask = is_alpha ? "a" : "rgb";
+
+    if (output.ab != PS_REGISTER_DISCARD) {
+        QString *ab_dest = get_var(ps, output.ab);
+        qstring_append_fmt(ps->code, "%s.%s = ab_out.%s;\n", qstring_get_str(ab_dest), write_mask, write_mask);
+        qobject_unref(ab_dest);
+    }
+
+    if (output.cd != PS_REGISTER_DISCARD) {
+        QString *cd_dest = get_var(ps, output.cd);
+        qstring_append_fmt(ps->code, "%s.%s = cd_out.%s;\n", qstring_get_str(cd_dest), write_mask, write_mask);
+        qobject_unref(cd_dest);
+    }
+
+    if (output.muxsum != PS_REGISTER_DISCARD) {
+        QString *sum_dest = get_var(ps, output.muxsum);
+        qstring_append_fmt(ps->code, "%s.%s = sum_out.%s;\n", qstring_get_str(sum_dest), write_mask, write_mask);
+        qobject_unref(sum_dest);
+    }
 }
 
 // Add code for the final combiner stage
@@ -603,6 +623,14 @@ static QString* psh_convert(struct PixelShader *ps)
     qstring_append(vars, "\n");
     qstring_append(vars, "vec4 v0 = pD0;\n");
     qstring_append(vars, "vec4 v1 = pD1;\n");
+    qstring_append(vars, "\n");
+    qstring_append(vars, "vec4 ab_in;\n");
+    qstring_append(vars, "vec4 ab_out;\n");
+    qstring_append(vars, "vec4 cd_in;\n");
+    qstring_append(vars, "vec4 cd_out;\n");
+    qstring_append(vars, "vec4 sum_in;\n");
+    qstring_append(vars, "vec4 sum_out;\n");
+
 
     ps->code = qstring_new();
 
@@ -748,6 +776,8 @@ static QString* psh_convert(struct PixelShader *ps)
         qstring_append_fmt(ps->code, "// Stage %d\n", i);
         add_stage_code(ps, ps->stage[i].rgb_input, ps->stage[i].rgb_output, false);
         add_stage_code(ps, ps->stage[i].alpha_input, ps->stage[i].alpha_output, true);
+        add_stage_code_writeback(ps, ps->stage[i].rgb_output, false);
+        add_stage_code_writeback(ps, ps->stage[i].alpha_output, true);
     }
 
     if (ps->final_input.enabled) {

--- a/hw/xbox/nv2a/nv2a_psh.c
+++ b/hw/xbox/nv2a/nv2a_psh.c
@@ -487,13 +487,12 @@ static void add_final_stage_code(struct PixelShader *ps, struct FCInputInfo fina
     QString *b = get_input_var(ps, final.b, false);
     QString *c = get_input_var(ps, final.c, false);
     QString *d = get_input_var(ps, final.d, false);
-    QString *g = get_input_var(ps, final.g, false);
+    QString *g = get_input_var(ps, final.g, true);
 
     qstring_append_fmt(ps->code, "fragColor.rgb = %s + mix(vec3(%s), vec3(%s), vec3(%s));\n",
                        qstring_get_str(d), qstring_get_str(c),
                        qstring_get_str(b), qstring_get_str(a));
-    /* FIXME: Is .x correctly here? */
-    qstring_append_fmt(ps->code, "fragColor.a = vec3(%s).x;\n", qstring_get_str(g));
+    qstring_append_fmt(ps->code, "fragColor.a = %s;\n", qstring_get_str(g));
 
     qobject_unref(a);
     qobject_unref(b);


### PR DESCRIPTION
Does a lot of smaller changes to bring our implementation closer to [NV_register_combiners](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_register_combiners.txt).

## Addressed problems

#### ~~Clamping in in- and outputs~~ Upstreamed

#### Number of components for inputs

WTF did I mean by this? vector sizes?

#### V1R0_SUM flags

#### ~~Final Combiner G is alpha~~ Upstreamed

#### Re-evaluation of GLSL expressions

Fix broken GLSL in case of MUX, also use correct types and avoid casts if not necessary

#### Data hazards

Variables might be overwritten before they get used as input because AB, CD and SUM should run in parallel and fill outputs for the next stage.

I've attempted to fix this, but the code is horrible.

This change makes the emulation more accurate and faster.


#### Many GL errors (possibly conflicting hardware states) are not checked

Someone will eventually have to try each of them.

---

TODO:

- Rebase onto the PSH cleanup and fix PR desc
- Testing