### PR TITLE
ac97: Allow 32-bit write to CR through index 08h

### DIFF
--- a/hw/audio/ac97.c
+++ b/hw/audio/ac97.c
@@ -913,6 +913,13 @@ static void nabm_writel (void *opaque, uint32_t addr, uint32_t val)
         dolog ("BDBAR[%d] <- %#x (bdbar %#x)\n",
                GET_BM (index), val, r->bdbar);
         break;
+    case PI_PICB:
+    case PO_PICB:
+    case MC_PICB:
+    case SO_PICB:
+        /* PICB, PIV and CR. But PICB and PIV are RO */
+        nabm_writeb(opaque, addr + 3, (val >> 24) & 0xff);
+        break;
     case GLOB_CNT:
         if (val & GC_WR)
             warm_reset (s);


### PR DESCRIPTION
OpenXDK XAudio writes 32-bit to NABMBAR + 08h to control CR. This actually works on hardware, but it is probably not allowed according to the AC97 / southbridge specification.

The Intel southbridge (IOCH6) implicitly forbids this. [See "16.2.5x_PICB—Position In Current Buffer Register" (page 599) in this intel document](https://www.intel.de/content/dam/doc/datasheet/io-controller-hub-6-datasheet.pdf). It explicitly allows 32-bit *reads*, but not writes. This is probably because PICB (08h) and PIV (0Ah) are RO (= read-only). Only CR (0Bh) is actually RW (= read/write).

This patch accepts the CR writes against the specification but ignores PICB and PIV, to work around issues with OpenXDK XAudio apps. XDK apps shouldn't be affected as they use the ACI differently.

I did not test wether the MCPX ACI might even have PICB or PIV as writeable registers.

However, this is purely for documentation purposes. I do not intend to send it upstream:
- For QEMU this is probably not suitable if it violates the specification.
- For XQEMU this would only be a temporary workaround, as we'll almost certainly need a custom ACI for XDK applications anyway (which supports the APU &harr; ACI link). It's probably easier to keep changes in AC97 to a minimum until then. I'll also fix this issue in OpenXDK XAudio, so new programs won't be affected.

*(I had a more brute-force variant of this a couple of years ago in https://github.com/JayFoxRox/xqemu-espes/pull/26)*